### PR TITLE
typos, missing reference

### DIFF
--- a/docs/source/app_compiling_fortran.rst
+++ b/docs/source/app_compiling_fortran.rst
@@ -157,13 +157,12 @@ for these errors, gfortran can add checks in the executable for these.
 To enable a certain check the -switch can be used to enable specific
 checks. Common checks are:
 
- -  Accessing array elements outside its bounds.
- -  Modification of loop variables.
- -  Memory allocation and deallocation.
- -  Runtime checks for pointer handling.
- -  Check for when an array-temporary has to be created for passing an
-   argument.
- -  Add all available runtime checks.
+ - Accessing array elements outside its bounds.
+ - Modification of loop variables.
+ - Memory allocation and deallocation.
+ - Runtime checks for pointer handling.
+ - Check for when an array-temporary has to be created for passing an argument.
+ - Add all available runtime checks.
 
 It is important to remove these checks in the final code as they add an
 additional overhead in the execution speed.

--- a/docs/source/app_compiling_fortran.rst
+++ b/docs/source/app_compiling_fortran.rst
@@ -10,7 +10,7 @@ Compiling single source Fortran programs
 ========================================
 
 To compile a simple Fortran 90 source file into an executable, execute
-the -command with the source file as the only argument:
+the `gfortran`-command with the source file as the only argument:
 
 ::
 
@@ -20,7 +20,7 @@ the -command with the source file as the only argument:
    $ ls
    a.out       myprog.f90
 
-This produces an executable called , which can be executed using the
+This produces an executable called `a.out`, which can be executed using the
 following command:
 
 :: 
@@ -28,9 +28,9 @@ following command:
    $ ./a.out 
     Hello, World!
 
-By default, the name of the executable will be , which is not always the
+By default, the name of the executable will be `a.out`, which is not always the
 best name for an executable. To tell the compiler to name the executable
-to something more meaningful the command line switch, , can be used as
+to something more meaningful the command line switch `o` can be used as
 shown in the following example:
 
 :: 
@@ -92,7 +92,7 @@ To debug a compiled executable using gdb or a graphical debugger, the
 executable needs to have debugging information included in the binary.
 By default gfortran does not add any debugging information in the
 executable. To tell the compiler to include this in the binary, the
--switch must be used. The following commands show how a debug enabled
+`g`-switch must be used. The following commands show how a debug enabled
 executable is built:
 
 ::

--- a/docs/source/chapter_fortran.rst
+++ b/docs/source/chapter_fortran.rst
@@ -1588,7 +1588,7 @@ The output routines in Fortran was originally intended to be used on row printer
 
     write(*,'(T1,A)') 'Hej hopp!'
 
-A more thorough description of the available format specifiers in Fortran is given in Metcalf and Reid~[metcalfreid18]_.
+A more thorough description of the available format specifiers in Fortran is given in Metcalf and Reid [metcalfreid18]_.
 
 Reading and Writing from files
 ------------------------------
@@ -1746,7 +1746,7 @@ Unformatted I/O
 
 In the previous sections data was read and written in human readable text format. For larger data structures this can be very inefficient. To solve this Fortran can also write data in its native binary format directly to disk. This can save space and can also be read and written much faster to disk. However, the binary format is not standardised and differs between different hardware platforms, preventing files to be used on different hardware.
 
-Reading and writing binary data is done using the same **read**- and wr**write**-ite statements as before, but without the formatting options. Writing an array to disk in binary form can be done with just one simple statement:
+Reading and writing binary data is done using the same **read**- and **write**- statements as before, but without the formatting options. Writing an array to disk in binary form can be done with just one simple statement:
 
 .. code-block:: Fortran
 
@@ -2065,7 +2065,7 @@ In Fortran 2003 object-oriented features where added to the language, making For
 
 The functionality and data structures of objects are defined in classes in most programming object-oriented languages. Classes can be seen as templates for objects. When an object is to be created the class is used as the template for the new object. Created objects are also called instances of a class.
 
-In Fortran the object-oriented features are implemented by extending the derived datatype concepts of fortran 90. A derived datatype now has a **contains**-section in which the procedures of the objects are specified. Derived datatypes are now also by definition objects or instances of the derived type.
+In Fortran the object-oriented features are implemented by extending the derived datatype concepts of Fortran 90. A derived datatype now has a **contains**-section in which the procedures of the objects are specified. Derived datatypes are now also by definition objects or instances of the derived type.
 
 To illustrate the concepts, a simple particle object is defined as an object in Fortran. The particle object is defined as a derived data type in a module, particles. To eliminate any name clashes when creating new objects of this type, the derived type is given the name, **particle_class**. This is also fits the object-oriented model of derived type being equivalent to classes. The initial class definition then becomes:
 

--- a/docs/source/chapter_fortran.rst
+++ b/docs/source/chapter_fortran.rst
@@ -1574,11 +1574,12 @@ The program produces the following output:
     \label{table:formatkoder}
     \end{table}
 
-During output a invisible cursor is moved from left to right. The format specifiers TR:math:`n` and T:math:`n` are used to move this cursor. TR:math:`n` moves the cursor :math:`n` positions to the right from the previous position. T:math:`n` places the cursor at position :math:`n`. Figure~\ref{fig:format_positiong} shows how this can be used in a write-statement.
+During output a invisible cursor is moved from left to right. The format specifiers TR:math:`n` and T:math:`n` are used to move this cursor. TR:math:`n` moves the cursor :math:`n` positions to the right from the previous position. T:math:`n` places the cursor at position :math:`n`. :numref:`fig-format-positioning` shows how this can be used in a write-statement.
 
 .. figure:: ../../images/format_positioning.svg
    :width: 100 %
    :alt: Positioning of output in Fortran 90/95
+   :name: fig-format-positioning
 
    Positioning of output in Fortran 90/95
 
@@ -1638,14 +1639,13 @@ The generated format code can now be used when printing the incoming array **A**
 
 .. code-block:: Fortran
 
-        ...
+     ...
         do i=1,rows
             print fmt, (A(i,j), j=1,cols)
         end do
             
         return
-    
-    end subroutine writeArray
+     end subroutine writeArray
 
 In the following main program, the implemented **writeArray** subroutine is used to print a 6 by 6 matrix.
 
@@ -1764,6 +1764,7 @@ Reading the same array back from disk is just as easy, using the **read**-statem
 
 It is also possible to write several variables to disk using multiple **write**- statements.
 
+
 .. code-block:: Fortran
 
     real :: A(100), B(200)
@@ -1876,11 +1877,12 @@ In the following code a file is opened for reading. Error handling code is added
    :language: Fortran
    :linenos:
 
-Figure~\ref{fig:error_handling} shows the flow of the program.
+:numref:`fig-error-handling` shows the flow of the program.
 
 .. figure:: ../../images/error_handling.svg
    :width: 35 %
    :alt: Error handling i Fortran I/O operations
+   :name: fig-error-handling
 
    Error handling i Fortran I/O operations
 

--- a/docs/source/chapter_fortran_projects.rst
+++ b/docs/source/chapter_fortran_projects.rst
@@ -290,8 +290,7 @@ Here the ``$<`` variable denotes the first prerequisite, . The target
 macro, ``$@``, is also used to define the outputfile for the compiler.
 
 There are several more internal macros that can be used in makefiles.
-For more information please see the GNU Make documenation
-:raw-latex:`\cite{gnumake12}`.
+For more information please see the GNU Make documenation [gnumake12]_.
 
 Suffix rules
 ------------
@@ -420,7 +419,7 @@ these dependencies in the make file. To illustrate this, consider the
 following example:
 
 myprog.f90
-   Main fortran program. Uses the mymodule module located in the
+   Main Fortran program. Uses the mymodule module located in the
    mymodule.f90 source file.
 
 mymodule.f90
@@ -766,7 +765,7 @@ This command extracts the filename component of the path and stores it
 in the variable . Next, an if-statement has to implemented that queries
 for different compilers. A string comparison can be done using the
 operator in CMake. Compilation flags for CMake are stored in for release
-mode flags and for debug flags. An example fo this king of conditional
+mode flags and for debug flags. An example of this kind of conditional
 compilation statement is shown below (from
 :raw-latex:`\cite{cmakecond12}`):
 

--- a/docs/source/chapter_fortran_projects.rst
+++ b/docs/source/chapter_fortran_projects.rst
@@ -493,7 +493,7 @@ Compiling code with cmake
 To use CMake, a CMakeLists.txt file has to be created. This is a normal
 text files with special CMake statements in it. Usually this files
 starts with a . This prevents the CMakeLists.txt file to be used by a
-too old cmake. The first actual statement is usually -function defining
+too old cmake. The first actual statement is usually `project`-function defining
 the name of the project.
 
 .. code-block:: CMake
@@ -505,13 +505,13 @@ The name of the project is not the same as the executable but is used
 when generating project files for development environments.
 
 CMake by default does not support Fortran, so a special function,
--function is used to enable this:
+`enable_language`-function is used to enable this:
 
 .. code-block:: CMake
 
    enable_language(Fortran)
 
-To create an executable the -function is used. This command takes an
+To create an executable the `add_executable`-function is used. This command takes an
 executable name as the first argument and a list of source files.
 
 .. code-block:: CMake
@@ -629,7 +629,7 @@ becomes:
    target_link_libraries(simple blas m)
 
 To show what switches that are actually used when building the
-executable, the , is set to . This will show the actual commands used
+executable, the `CMAKE_VERBOSE_MAKEFILE`, is set to `ON`. This will show the actual commands used
 during the build.
 
 ::
@@ -664,7 +664,7 @@ following if statement can be used:
        message("This is a Unix build.")
    endif (UNIX)
 
-is predefined variable that is true when building on Unix-type system.
+`UNIX` is a predefined variable that is true when building on Unix-type system.
 When running CMake on a Unix-type system will print ”This is a Unix
 build.” on the console.
 
@@ -687,7 +687,7 @@ target and adds different build options depending on the platform used:
 
 It is also possible to use variables in CMake. Variables can be both
 strings and lists of strings. A variable is created by using the
--function. The following example shows how a simple string variable is
+`set`-function. The following example shows how a simple string variable is
 created:
 
 .. code-block:: CMake
@@ -706,7 +706,7 @@ This will print the contents of the variable, . If not enclosed it will
 print the name of the variable.
 
 Variables can also be lists of values which can be iterated over.
-Creating a list is also done using the -function, as shown in this
+Creating a list is also done using the `set`-function, as shown in this
 example:
 
 .. code-block:: CMake

--- a/docs/source/chapter_fortran_projects.rst
+++ b/docs/source/chapter_fortran_projects.rst
@@ -492,7 +492,7 @@ Compiling code with cmake
 
 To use CMake, a CMakeLists.txt file has to be created. This is a normal
 text files with special CMake statements in it. Usually this files
-starts with a . This prevents the CMakeLists.txt file to be used by a
+starts with a `cmake_minimum_required`. This prevents the CMakeLists.txt file to be used by a
 too old cmake. The first actual statement is usually `project`-function defining
 the name of the project.
 

--- a/docs/source/chapter_qtcreator.rst
+++ b/docs/source/chapter_qtcreator.rst
@@ -4,7 +4,7 @@ Qt Creator for Fortran
 
 Qt Creator is a integrated development environment, IDE, for C++ and Qt, but can be easily adapted as a development environment for Fortran using plugins provided together with this book.
 
-The user interface of Qt Creator resembles the one found in commercial alternatives such as Microsoft Visual Studio or Inte Visual Fortran. This chapter gives a short introduction on how to get started with this development enviroment.
+The user interface of Qt Creator resembles the one found in commercial alternatives such as Microsoft Visual Studio or Intel Visual Fortran. This chapter gives a short introduction on how to get started with this development enviroment.
 
 To be able to use the Fortran Project templates and compile Fortran code in Qt Creator, require the following pre-requisites:
 

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -3,3 +3,4 @@ References
 **********
 
 .. [metcalfreid18] Modern Fortran Explained: Incorporating FORTRAN 2018, Oxford University Press, 2018, ISBN-13 978-0198811886
+.. [gnumake12]  GNU Make Manual - GNU Project - Free Software Foundation. https://www.gnu.org/software/make/manual/. Accessed 15 Oct. 2023


### PR DESCRIPTION
Hello, and thanks for a great tutorial. 

While reading this, I've noticed few typos and it seems that the conversion from LaTeX did not translate inline code (e.g. names of variables and functions mentioned in text). This PR aims to fix these.